### PR TITLE
Consolidate Tailscale Connection Steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,8 @@ jobs:
           oauth-client-id: ${{ secrets.TAILSCALE_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_CLIENT_SECRET }}
           tags: tag:developer-ci-pipeline
-
-      - name: Advertise Ephemeral Node to Murdock
-        uses: tailscale/github-action@v4
-        with:
           ping: ${{ secrets.MURDOCK_HOST }}
-        
+          
       - name: Add Pi to known hosts
         run: |
           mkdir -p ~/.ssh


### PR DESCRIPTION
Removed the step to advertise the ephemeral node to Murdock in the release workflow.